### PR TITLE
add `/repo` short link

### DIFF
--- a/url.map.js
+++ b/url.map.js
@@ -23,4 +23,5 @@
   "/pro-v2-default-settings": "https://github.com/ant-design/ant-design-pro/tree/master/src/defaultSettings.js",
   "/faq": "https://github.com/ant-design/ant-design/issues?q=is%3Aissue+label%3A%E2%9D%93FAQ+is%3Aclosed",
   "/reproduce": "https://stackblitz.com/edit/antd-reproduce-5x",
+  "/repo": "https://stackblitz.com/edit/antd-reproduce-5x"
 };


### PR DESCRIPTION
作为 `/reproduce` 的别名，（个人认为链接应该越短越好。

添加一个 `/repo` 也避免之前 antd 的 ci 发表的评论中链接变成死链... ref: https://github.com/ant-design/ant-design/pull/49746/files

antd repo 为此还修复过 readme 的 repo 链接： https://github.com/ant-design/ant-design/issues/50151