### PR TITLE
feat: add `/setup`

### DIFF
--- a/url.map.js
+++ b/url.map.js
@@ -25,5 +25,6 @@
   "/stackblitz": "https://stackblitz.com/edit/antd-reproduce-5x",
   "/reproduce": "https://codesandbox.io/s/antd-reproduction-template-forked-jyh2k9",
   "/repro": "https://codesandbox.io/s/antd-reproduction-template-forked-jyh2k9",
-  "/v5-for-19": "https://ant.design/docs/react/v5-for-19"
+  "/v5-for-19": "https://ant.design/docs/react/v5-for-19",
+  "/setup": "http://ant.design/docs/react/use-with-vite",
 };


### PR DESCRIPTION
wiki 和 issues 的 reproduce 中的描述链接已经过期了，是否可以修改为重定向地址？

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/26ba6a55-9f84-498f-8147-263287d48008" />

---

<img width="866" alt="image" src="https://github.com/user-attachments/assets/96ea39e5-e68d-4869-9a5b-0c7ad8ca1826" />

